### PR TITLE
Fixed logo size on mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -4,6 +4,14 @@
 @use "@styles/z-index";
 @use "@styles/misc";
 
+.logo {
+  width: 7.375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+  }
+}
+
 .container,
 .fixedContainer {
   width: 100%;
@@ -16,6 +24,10 @@
   }
 
   &.isCollapsed {
+    .logo {
+      width: 1.4375rem;
+    }
+
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
 
@@ -45,14 +57,6 @@
   @media (min-width: breakpoint.$desktop) {
     height: unset;
     padding: space.$s8 space.$s4 space.$s6;
-  }
-}
-
-.logo {
-  width: 7.375rem;
-
-  @media (min-width: breakpoint.$desktop) {
-    margin: space.$s0 space.$s4;
   }
 }
 


### PR DESCRIPTION
Changed the width size to something smaller, but within the .container class.  Specifically when the desktop breakpoint is past certain point AND when 'isCollapsed' condition is met, then logo is set to smaller size.